### PR TITLE
Update Mutex implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 
 <!-- markdownlint-enable MD033 -->
 
--   **Easy to use**: Get up and running with the library in minutes
+- **Easy to use**: Get up and running with the library in minutes
 
--   **Actively developed**: Ideas and contributions welcomed!
+- **Actively developed**: Ideas and contributions welcomed!
 
 ---
 
@@ -29,70 +29,36 @@
 
 </div>
 
-## Getting Started  
+## Getting Started
 
-### Prerequisites  
+### Prerequisites
 
-- Download and install Go, version 1.22+, from the [official Go website](https://go.dev/doc/install).  
+- Download and install Go, version 1.22+, from the [official Go website](https://go.dev/doc/install).
 - If you do not already have a LibreLinkUp account, create one by downloading the LibreLinkUp App from the [iOS App Store](https://apps.apple.com/us/app/librelinkup/id1234323923) or [Google Play Store](https://play.google.com/store/apps/details?id=org.nativescript.LibreLinkUp)
 
+> [!TIP]
+> To make sure that your account credentials will work with the library, you can download the [bruno](https://www.usebruno.com/) application or the [Postman](https://www.postman.com/) application and test the requests manually.
+> If you choose to download and use bruno, see the ./ops/docs/bruno folder for example requests.
 
-> [!TIP] 
-> To make sure that your account credentials will work with the library, you can download the [bruno](https://www.usebruno.com/) application or the [Postman](https://www.postman.com/) application and test the requests manually.  
-
-### Install  
+### Install
 
 ```shell
-go get github.com/equalsgibson/golibre@latest
+go get github.com/equalsgibson/golibre@v0.0.2-alpha
 ```
 
 #### Get the Connections shared with your account
 
 Below is a short example showing how to get the connections from your account
 
-> [!NOTE] 
-> Make sure to `go get` the library, and set the required ENV variables (`LIBRELINKUP_EMAIL` and `LIBRELINKUP_PASSWORD`) before running the below example.
+> [!NOTE]
+> Make sure to `go get` the library, and set the required ENV variables (`EMAIL` and `PASSWORD`) before running the below example.
 
-```go
-package main
+https://github.com/equalsgibson/golibre/blob/59176f70461221b2e021caf02e574bf3816a40de/examples/main.go
 
-import (
-	"context"
-	"log"
-	"os"
-	"fmt"
+Expected Output:
 
-	"github.com/equalsgibson/golibre/golibre"
-)
-
-func main() {
-	// Set up a new golibre service
-	ctx := context.Background()
-	service := golibre.NewService(
-		"api.libreview.io",
-		golibre.Authentication{
-			Email:    os.Getenv("LIBRELINKUP_EMAIL"),    // Your email address
-			Password: os.Getenv("LIBRELINKUP_PASSWORD"), // Your password
-		},
-	)
-
-	connections, err := service.Connection().GetAllConnectionData(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Print a count of all the patients that you are connected to, with a list of patient IDs
-	fmt.Printf("You have %d patients that are sharing their data with you.\n", len(connections))
-
-	for i, connection := range connections {
-		fmt.Printf("\t-> Patient %d: ID: %s\n", i+1, connection.PatientID)
-	}
-}
-```  
-
-Expected Output:  
 ```bash
-cgibson@wsl-ubuntuNexus:~/git/libre/golibre$ go run examples/main.go 
+cgibson@wsl-ubuntuNexus:~/git/libre/golibre$ go run examples/main.go
 You have 1 patients that are sharing their data with you.
         -> Patient 1: ID: 12345678-1234-1234-abcd-0242ac110002
 ```
@@ -125,7 +91,6 @@ Distributed under a GNU License. See the `LICENSE` file for more information.
 [Chris Gibson (@equalsgibson)](https://github.com/equalsgibson)
 
 Project Link: [https://github.com/equalsgibson/golibre](https://github.com/equalsgibson/golibre)
-
 
 <!-- MARKDOWN LINKS & IMAGES -->
 <!-- https://www.markdownguide.org/basic-syntax/#reference-style-links -->

--- a/golibre/connection.go
+++ b/golibre/connection.go
@@ -3,14 +3,10 @@ package golibre
 import (
 	"context"
 	"net/http"
-	"time"
-
-	"github.com/equalsgibson/golibre/golibre/internal"
 )
 
 type ConnectionService struct {
 	client *client
-	store  *internal.SimpleStore[PatientID, []GraphGlucoseMeasurement]
 }
 
 func (c *ConnectionService) GetAllConnectionData(ctx context.Context) ([]ConnectionData, error) {
@@ -53,43 +49,6 @@ func (c *ConnectionService) GetConnectionGraph(ctx context.Context, patientID Pa
 	}
 
 	return target.Data, nil
-}
-
-func (c *ConnectionService) RegisterConnectionInStore(ctx context.Context, patientID PatientID, updateInterval time.Duration) error {
-	patientData, err := c.GetConnectionGraph(ctx, patientID)
-	if err != nil {
-		return err
-	}
-
-	newConnection := map[PatientID][]GraphGlucoseMeasurement{
-		patientData.Connection.PatientID: patientData.GraphData,
-	}
-
-	c.store.Set(newConnection)
-
-	return nil
-}
-
-func (c *ConnectionService) UnregisterConnectionInStore(ctx context.Context, patientID PatientID) {
-	c.store.Evict(patientID)
-}
-
-func (c *ConnectionService) pollRegisteredConnections(ctx context.Context) error {
-	registeredConnections := c.store.GetAll(ctx)
-	updatedData := make(map[PatientID][]GraphGlucoseMeasurement, len(registeredConnections))
-
-	for registeredConnection := range registeredConnections {
-		data, err := c.GetConnectionGraph(ctx, registeredConnection)
-		if err != nil {
-			return err
-		}
-
-		updatedData[registeredConnection] = data.GraphData
-	}
-
-	c.store.Set(updatedData)
-
-	return nil
 }
 
 type ConnectionGraphResponse BaseResponse[ConnectionGraphData]

--- a/golibre/internal/cache.go
+++ b/golibre/internal/cache.go
@@ -1,0 +1,75 @@
+package internal
+
+import (
+	"container/heap"
+	"sync"
+)
+
+type Cache[T any] struct {
+	mutex *sync.Mutex
+	data  map[string]Item[T]
+
+	evictionPolicy *lfuHeap
+	size           int
+}
+
+func NewCache[T any]() *Cache[T] {
+	return &Cache[T]{}
+}
+
+func (c *Cache[T]) Get(key string) (T, bool) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	item, itemExists := c.data[key]
+	if itemExists {
+		item.frequency++
+	}
+
+	return item.value, itemExists
+}
+
+func (c *Cache[T]) Set(newData map[string]T) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	for k, v := range newData {
+		newItem := &Item[T]{
+			key:       k,
+			value:     v,
+			frequency: 1,
+		}
+
+		c.data[k] = *newItem
+		heap.Push(c.evictionPolicy, newItem)
+	}
+}
+
+type lfuHeap []int
+
+func (l lfuHeap) Len() int {
+	return len(l)
+}
+
+func (l lfuHeap) Less(i, j int) bool {
+	return l[i] < l[j]
+}
+
+func (l lfuHeap) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+func (l *lfuHeap) Push(x interface{}) {
+	if x, xIsInt := x.(int); xIsInt {
+		*l = append(*l, x)
+	}
+}
+
+func (l *lfuHeap) Pop() interface{} {
+	old := *l
+	n := len(old)
+	x := old[n-1]
+	*l = old[:n-1]
+
+	return x
+}

--- a/golibre/internal/simple_store.go
+++ b/golibre/internal/simple_store.go
@@ -1,0 +1,77 @@
+package internal
+
+import (
+	"context"
+	"sync"
+)
+
+func NewSimpleStore[Key comparable, T any]() *SimpleStore[Key, T] {
+	return &SimpleStore[Key, T]{
+		mutex: &sync.RWMutex{},
+		items: map[Key]T{},
+	}
+}
+
+type SimpleStore[Key comparable, T any] struct {
+	mutex *sync.RWMutex
+	items map[Key]T
+}
+
+func (s *SimpleStore[Key, T]) Set(newData map[Key]T) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for key, data := range newData {
+		s.items[key] = data
+	}
+}
+
+func (s *SimpleStore[Key, T]) Evict(key Key) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	delete(s.items, key)
+}
+
+func (s *SimpleStore[Key, T]) Get(ctx context.Context, key Key) (item T, exists bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	item, exists = s.items[key]
+
+	return item, exists
+}
+
+func (s *SimpleStore[Key, T]) GetMultiple(ctx context.Context, keys []Key) (map[Key]T, []Key) {
+	results := make(map[Key]T)
+	misses := []Key{}
+
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	for _, key := range keys {
+		item, itemExists := s.items[key]
+		if !itemExists {
+			misses = append(misses, key)
+
+			continue
+		}
+
+		results[key] = item
+	}
+
+	return results, misses
+}
+
+func (s *SimpleStore[Key, T]) GetAll(ctx context.Context) map[Key]T {
+	results := make(map[Key]T)
+
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	for key, value := range s.items {
+		results[key] = value
+	}
+
+	return results
+}

--- a/golibre/internal/store.go
+++ b/golibre/internal/store.go
@@ -1,0 +1,67 @@
+package internal
+
+import (
+	"context"
+	"sync"
+)
+
+type Cacher[K comparable, T any] interface {
+	Get(ctx context.Context, key K) (Item[T], bool)
+	Set(newData map[K]Item[T])
+}
+
+func NewStore[Key comparable, T any]() *Store[Key, T] {
+	return &Store[Key, T]{
+		mutex: &sync.RWMutex{},
+		items: map[Key]Item[T]{},
+	}
+}
+
+type Store[Key comparable, T any] struct {
+	mutex *sync.RWMutex
+	items map[Key]Item[T]
+}
+
+func (s *Store[Key, T]) Set(newData map[Key]Item[T]) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	s.items = newData
+}
+
+func (s *Store[Key, T]) Get(ctx context.Context, key Key) (item Item[T], exists bool) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	item, exists = s.items[key]
+
+	return item, exists
+}
+
+func (s *Store[Key, T]) GetMultiple(ctx context.Context, keys []Key) (map[Key]Item[T], []Key) {
+	results := make(map[Key]Item[T])
+	misses := []Key{}
+
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+
+	for _, key := range keys {
+		item, itemExists := s.items[key]
+		if !itemExists {
+			misses = append(misses, key)
+
+			continue
+		}
+
+		results[key] = item
+	}
+
+	return results, misses
+}
+
+type Item[T any] struct {
+	key       string
+	value     T
+	frequency int
+	index     int
+}

--- a/golibre/internal/store_test.go
+++ b/golibre/internal/store_test.go
@@ -1,0 +1,32 @@
+package internal_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/equalsgibson/golibre/golibre"
+	"github.com/equalsgibson/golibre/golibre/internal"
+)
+
+func BenchmarkStoreOperations(b *testing.B) {
+	// Set up
+	keys := []golibre.UserID{}
+	items := map[golibre.UserID]internal.Item[[]golibre.GraphGlucoseMeasurement]{}
+
+	for i := range 100 {
+		k := golibre.UserID(fmt.Sprint(i))
+		keys = append(keys, k)
+		items[k] = internal.Item[[]golibre.GraphGlucoseMeasurement]{}
+	}
+
+	store := internal.NewStore[golibre.UserID, []golibre.GraphGlucoseMeasurement]()
+	store.Set(items)
+
+	b.ResetTimer()
+	b.RunParallel(func(p *testing.PB) {
+		for p.Next() {
+			store.GetMultiple(context.Background(), keys)
+		}
+	})
+}

--- a/golibre/service.go
+++ b/golibre/service.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/equalsgibson/golibre/golibre/internal"
 )
 
 type Service struct {
@@ -53,7 +55,7 @@ func NewService(
 		authentication: auth,
 		apiURL:         apiURL,
 		jwt: jwtAuth{
-			mutex: &sync.Mutex{},
+			mutex: &sync.RWMutex{},
 		},
 	}
 
@@ -64,6 +66,7 @@ func NewService(
 		},
 		connectionService: &ConnectionService{
 			client: c,
+			store:  internal.NewSimpleStore[PatientID, []GraphGlucoseMeasurement](),
 		},
 		userService: &UserService{
 			client: c,

--- a/golibre/service.go
+++ b/golibre/service.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"sync"
 	"time"
-
-	"github.com/equalsgibson/golibre/golibre/internal"
 )
 
 type Service struct {
@@ -66,7 +64,6 @@ func NewService(
 		},
 		connectionService: &ConnectionService{
 			client: c,
-			store:  internal.NewSimpleStore[PatientID, []GraphGlucoseMeasurement](),
 		},
 		userService: &UserService{
 			client: c,


### PR DESCRIPTION
Initially this was going to add a in-memory cache (using sync.map, map[] or similar and mutexes), however I realised that this would likely be more of a "business logic" requirement - this API Library should only handle getting the data. Storing the result of the API Calls (either in memory or to a persistent location (DB, file etc)) should be handled separately depending on requirements of the consumer. 

I left the stores that I was looking at implementing inside the "internal" folder for future reference, if something like this is considered again.